### PR TITLE
The fix for creating a service directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ LPVERSION := \"$(LPVERSION_MAJOR).$(LPVERSION_MINOR).$(LPVERSION_BUGFX)\"
 
 KTVERSION_MAJOR := 4
 KTVERSION_MINOR := 0
-KTVERSION_BUGFX := 0
+KTVERSION_BUGFX := 1
 KTCUST_VERSION  := 24
 
 ################################################################################

--- a/source/kiptool/kipWizard/kipWizard.c
+++ b/source/kiptool/kipWizard/kipWizard.c
@@ -73,6 +73,7 @@ void memcpy_kt(u8* dst, const u8* src, const unsigned int size) {
 }
 
 int kipWizard(char* path, FSEntry_t entry) {
+    createKTDirIfNotExist();
     char* filePath = CombinePaths(path, entry.name);
 
     FIL kipFile;

--- a/source/kiptool/kiptoolMenu.h
+++ b/source/kiptool/kiptoolMenu.h
@@ -12,7 +12,6 @@ MenuEntry_t kipToolMenuEntries[] = {
 const int (*kipToolMenuPaths[])(char*, FSEntry_t) = {[KTWizard] = kipWizard};
 
 void drawKipToolMenu(char* path, FSEntry_t entry) {
-    createKTDirIfNotExist();
     Vector_t ent = vecFromArray(kipToolMenuEntries, ARR_LEN(kipToolMenuEntries), sizeof(MenuEntry_t));
     gfx_boxGrey(384, 200, 384 + 512, 200 + 320, 0x33);
     gfx_con_setpos(384 + 16, 200 + 16);


### PR DESCRIPTION
- [FIXED] In the absence of a service directory (`sd:/.kt`) and direct opening of the wizard, the session file was not created